### PR TITLE
Update for PoE 2.4

### DIFF
--- a/sayya_default.filter
+++ b/sayya_default.filter
@@ -30,7 +30,7 @@
 # Add a currency-colored border to midtier currency
 Show # Currency - Mid
     Class "Currency"
-    BaseType "Fusing" "Regret" "Gemcutter's Prism" "Chisel" "Blessed" "Regal Orb" "Vaal Orb" "Chaos Orb" "Alchemy" "Scouring" "Perandus Coin" "Silver Coin" "Prophecy"
+    BaseType "Fusing" "Regret" "Gemcutter's Prism" "Chisel" "Blessed" "Regal Orb" "Vaal Orb" "Chaos Orb" "Alchemy" "Scouring" "Perandus Coin" "Silver Coin" "Prophecy" "Remnant of Corruption" "Cartographer's Sextant" "Cartographer's Seal" "Unshaping Orb"
     SetBorderColor 170 158 130 # Uncommon currency
     SetFontSize 38
 	PlayAlertSound 3 300
@@ -64,7 +64,7 @@ Show # Valuables - Uniques
     SetFontSize 42
 	
 Show # Labyrinth - Trinkets
-	BaseType "Sand of Eternity" "Orb of Elemental Essence" "Rod of Detonation" "Cube Of Absorption" "Bane of the Loyal" "Heart of the Gargoyle" "Cogs of Disruption" "Portal Shredder"
+	BaseType "Sand of Eternity" "Rod of Detonation" "Cube Of Absorption" "Bane of the Loyal" "Heart of the Gargoyle" "Cogs of Disruption" "Portal Shredder"
 	SetFontSize 38
 
 Show # Labyrinth - Keys


### PR DESCRIPTION
- remove "Orb of Elemental Essence" because no more baseType mathing it was found
- add Sheriff_K suggestion (https://www.pathofexile.com/forum/view-thread/1260712/page/12)
